### PR TITLE
Switch to PNG image file format

### DIFF
--- a/taf-base/src/main/java/com/baloise/testautomation/taf/base/testing/ScreenshotRule.java
+++ b/taf-base/src/main/java/com/baloise/testautomation/taf/base/testing/ScreenshotRule.java
@@ -71,11 +71,11 @@ public class ScreenshotRule extends TestWatcher {
       }
     }
     methodName = String.format("%1.100s", methodName);    
-    return System.currentTimeMillis() + "_" + methodName + ".jpg";
+    return System.currentTimeMillis() + "_" + methodName + ".png";
   }
 
   public void saveScreenShot() {
-    saveScreenShot("screenshot_" + System.currentTimeMillis() + ".jpg");
+    saveScreenShot("screenshot_" + System.currentTimeMillis() + ".png");
   }
 
   public void saveScreenShot(String filename) {
@@ -87,7 +87,7 @@ public class ScreenshotRule extends TestWatcher {
       Robot robot = new Robot();
       BufferedImage image = robot.createScreenCapture(rectangle);
       File f = new File(path + filename);
-      ImageIO.write(image, "jpg", f);
+      ImageIO.write(image, "png", f);
       logger.info("Done saveScreenShot() " + f);
     }
     catch (Exception ex) {


### PR DESCRIPTION
Switch to PNG image file format (instead of JPG) due to
 - lossless compression
 - thereby 1:1 (image) bit comparability e.g. for heuristic algorithms
 - smaller file size (when not using high complex wallpaper / image backgrounds)