### PR TITLE
Components using parents to define the scope

### DIFF
--- a/taf-base/src/main/java/com/baloise/testautomation/taf/base/_base/AElement.java
+++ b/taf-base/src/main/java/com/baloise/testautomation/taf/base/_base/AElement.java
@@ -84,8 +84,6 @@ public abstract class AElement implements IElement {
     fail("element after " + seconds + " seconds not found: " + name);
   }
 
-  public abstract Object find();
-
   public Object brFind() {
     assertComponentNotNull();
     Object we = null;

--- a/taf-base/src/main/java/com/baloise/testautomation/taf/base/_base/AElement.java
+++ b/taf-base/src/main/java/com/baloise/testautomation/taf/base/_base/AElement.java
@@ -93,7 +93,11 @@ public abstract class AElement implements IElement {
       we = brFindByCustom();
     }
     if (we == null) {
-      we = component.getBrowserFinder().find(by);
+      Object parent = null;
+      if (this.component != null) {
+        parent = this.component.find();
+      }
+      we = component.getBrowserFinder().find(parent, by);
     }
     assertNotNull("webelement NOT found: " + name + TafError.getByInfo(by), we);
     return we;

--- a/taf-base/src/main/java/com/baloise/testautomation/taf/base/_interfaces/IComponent.java
+++ b/taf-base/src/main/java/com/baloise/testautomation/taf/base/_interfaces/IComponent.java
@@ -17,13 +17,13 @@ public interface IComponent extends IFill, ICheck, IElement {
 
   public IComponent findFirstParent(Class<? extends IComponent> clazz);
 
-  public IFinder<?> getBrowserFinder();
+  public <T> IFinder<T> getBrowserFinder();
 
   public TafString getCheck();
 
   public TafString getFill();
 
-  public IFinder<?> getSwingFinder();
+  public <T> IFinder<T> getSwingFinder();
 
   public boolean isCheckCustom();
 

--- a/taf-base/src/main/java/com/baloise/testautomation/taf/base/_interfaces/IComponent.java
+++ b/taf-base/src/main/java/com/baloise/testautomation/taf/base/_interfaces/IComponent.java
@@ -23,7 +23,7 @@ public interface IComponent extends IFill, ICheck, IElement {
 
   public TafString getFill();
 
-  public <T> IFinder<T> getSwingFinder();
+  public <U> IFinder<U> getSwingFinder();
 
   public boolean isCheckCustom();
 

--- a/taf-base/src/main/java/com/baloise/testautomation/taf/base/_interfaces/IElement.java
+++ b/taf-base/src/main/java/com/baloise/testautomation/taf/base/_interfaces/IElement.java
@@ -5,8 +5,10 @@ import java.lang.annotation.Annotation;
 public interface IElement {
 
   public void click();
-
-  // public Object find();
+  
+  default public <T> T find() {
+    return null;
+  }
 
   public void setBy(Annotation by);
 


### PR DESCRIPTION
With this changes applied, the parent component containing other components as well as elements, can now be used as a defining scope.